### PR TITLE
Enhance blog page content and navigation

### DIFF
--- a/dist/blog.css
+++ b/dist/blog.css
@@ -60,3 +60,51 @@ body {
   color: white;
   transition: 0.3s ease;
 }
+.back-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.5rem 1rem;
+  border-radius: 999px;
+  color: #faf7f0;
+  background-color: rgba(139, 133, 133, 0.3);
+  text-decoration: none;
+  transition: background-color 0.3s ease, transform 0.3s ease;
+}
+
+.back-link:hover {
+  background-color: rgba(92, 131, 116, 0.8);
+  transform: translateX(-4px);
+  color: #faf7f0;
+}
+
+.blog-article {
+  background: rgba(255, 255, 255, 0.25);
+  border-radius: 1.5rem;
+  padding: 2rem;
+  box-shadow: 0 10px 40px rgba(0, 0, 0, 0.1);
+  backdrop-filter: blur(10px);
+  color: inherit;
+}
+
+.blog-article h2 {
+  font-size: 2rem;
+  margin-bottom: 1rem;
+}
+
+.blog-article p {
+  font-size: 1.1rem;
+  line-height: 1.7;
+  margin-bottom: 1rem;
+}
+
+@media (max-width: 991px) {
+  .back-link {
+    width: 100%;
+    justify-content: center;
+  }
+
+  .blog-article {
+    padding: 1.5rem;
+  }
+}

--- a/dist/blog.html
+++ b/dist/blog.html
@@ -14,26 +14,68 @@
 <body>
     <section class="container">
         <div class="h-100 d-flex flex-wrap glass-card">
-            <div class="  mt-5">
+            <div class="mt-4 w-100">
                 <div class="row align-self-center">
-                    <div class="mb-3">
-                        <h1>Welcome to my blog</h1>
+                    <div class="d-flex justify-content-between align-items-center flex-wrap gap-3 mb-4">
+                        <a class="back-link" href="index.html"><i class="bi bi-arrow-left"></i> Vissza a főoldalra</a>
+                        <h1 class="mb-0">Welcome to my blog</h1>
                     </div>
-                    <div class="col-md-3">
+                    <div class="col-lg-3 mb-4">
                         <h3>Topics</h3>
                         <ul class="list-unstyled">
                             <li class="list-group-item mb-3">
-                                <a href="">Designing a glassmorphism layout</a>
+                                <a href="#glassmorphism">Designing a glassmorphism layout</a>
                             </li>
                             <li class="list-group-item mb-3">
-                                <a href="">My first portfolio</a>
+                                <a href="#first-portfolio">My first portfolio</a>
+                            </li>
+                            <li class="list-group-item mb-3">
+                                <a href="#accessibility">Keeping accessibility in mind</a>
+                            </li>
+                            <li class="list-group-item mb-3">
+                                <a href="#career-path">From hobby to a career</a>
                             </li>
                         </ul>
                     </div>
-                    <div class="col-md-8">
-                        <p id="blogText">Lorem, ipsum dolor sit amet consectetur adipisicing elit. Neque eos, deserunt non voluptate
-                            iusto ratione itaque corporis quis nam, ducimus minus veniam harum officia, voluptates odio
-                            debitis! Aut, eius voluptas?</p>
+                    <div class="col-lg-8 offset-lg-1">
+                        <article id="glassmorphism" class="blog-article mb-5">
+                            <h2>Designing a glassmorphism layout</h2>
+                            <p>Glassmorphism quickly became one of my favourite styles because it blends subtle gradients with
+                                transparency. When I start a new design, I spend time defining a soft colour palette and a set of
+                                layers that let the background shine through without sacrificing contrast.</p>
+                            <p>To make the layout work on different screen sizes, I iterate with the browser&apos;s responsive tools and
+                                move elements around until the composition feels balanced. The key is to lean on spacing, rounded
+                                corners and blurred backgrounds so the card components stay readable even on a busy photo.</p>
+                        </article>
+
+                        <article id="first-portfolio" class="blog-article mb-5">
+                            <h2>My first portfolio</h2>
+                            <p>My first portfolio was nothing more than a single page with a handful of screenshots, but it taught me
+                                how important storytelling is. Each project needs context: the challenge, the process and the outcome.
+                                I now prepare small write-ups before I even touch the code so that visitors understand the impact of the
+                                work.</p>
+                            <p>Version control, design systems and reusable components were all strangers to me back then. Revisiting
+                                that old project motivated me to adopt better tools and to document the journey in posts like this one.</p>
+                        </article>
+
+                        <article id="accessibility" class="blog-article mb-5">
+                            <h2>Keeping accessibility in mind</h2>
+                            <p>Accessibility is more than passing automated tests. I regularly review colour contrast, keyboard
+                                navigation and semantic markup. For example, headings should form a clear hierarchy and links should
+                                describe their destination&mdash;small details that make the experience smoother for everyone.</p>
+                            <p>When writing content I try to avoid jargon, add descriptive alt texts and provide transcripts for
+                                multimedia. These practices take extra time, yet they often surface improvements that benefit the entire
+                                interface.</p>
+                        </article>
+
+                        <article id="career-path" class="blog-article">
+                            <h2>From hobby to a career</h2>
+                            <p>What began as a weekend hobby evolved into a full-time pursuit once I realised how much joy I get from
+                                solving real problems for people. Sharing progress through this blog helped me connect with peers,
+                                receive feedback and, eventually, open doors to new collaborations.</p>
+                            <p>If you are on a similar path, keep experimenting and document your steps. The portfolio becomes a living
+                                archive of your skills while the blog captures the lessons you learn along the way.</p>
+                        </article>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
## Summary
- add a back navigation link on the blog page to return to the home screen
- expand the list of blog topics and replace placeholder text with multiple detailed articles
- style the new navigation and article sections to match the glassmorphism theme and keep them responsive

## Testing
- no automated tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68fb34aa65f88328bb37024c514a0f20